### PR TITLE
bumped runtime to node 8.10

### DIFF
--- a/oauth-token-api/serverless.yml
+++ b/oauth-token-api/serverless.yml
@@ -4,9 +4,8 @@ service: oauth-token-api
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs8.10
   region: eu-central-1
-  profile: festify
   memorySize: 128
 
 package:


### PR DESCRIPTION
bumped runtime (nodejs 4.3 is EOL. From AWS email: The Node Foundation declared End-of-Life (EOL) for Node.js v4 on April 30, 2018. As a result, this version of Node.js is no longer receiving bug fixes, security updates, or performance improvements from the Node Foundation. Per the AWS Lambda runtime support policy [2] , language runtimes that have been end-of-lifed by the supplier are deprecated in AWS Lambda.)

Deployed and tested code runs ok.

remove profile since specific to festify