### PR TITLE
Update README.md - forget() is not a Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ cordova.plugins.spotifyAuth.authorize(config)
 
 ### Log out
 ```js
-cordova.plugins.spotifyAuth.forget()
-  .then(() => console.log("We're logged out!"));
+cordova.plugins.spotifyAuth.forget();
 ```
 
 ## Installation


### PR DESCRIPTION
`cordova.plugins.spotifyAuth.forget();` is not a Promise. The API documentation site is correct on this.