### PR TITLE
iOS: Removed dependency on legacy Spotify SDK

### DIFF
--- a/install-ios.sh
+++ b/install-ios.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-INSTALL_PATH="plugins/cordova-spotify-oauth/src/ios/spotify-sdk"
-DOWNLOAD_PATH="https://github.com/spotify/ios-streaming-sdk/archive/beta-27.tar.gz"
-
-if [ ! -d $INSTALL_PATH ]; then
-    mkdir -p $INSTALL_PATH
-    curl -LsS $DOWNLOAD_PATH | tar -xz -C $INSTALL_PATH --strip 1
-fi

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,8 +27,6 @@
     </platform>
 
     <platform name="ios">
-        <hook type="before_plugin_install" src="install-ios.sh"/>
-
         <config-file target="config.xml" parent="/*">
             <feature name="SpotifyOAuth">
                 <param name="ios-package" value="SpotifyOAuthPlugin"/>
@@ -36,8 +34,6 @@
         </config-file>
 
         <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
-
-        <framework src="src/ios/spotify-sdk/SpotifyAuthentication.framework" custom="true"/>
 
         <source-file src="src/ios/SpotifyOAuthPlugin.swift"/>
         <header-file src="src/ios/SpotifyOAuth-Bridging-Header.h"/>

--- a/src/ios/SpotifyOAuth-Bridging-Header.h
+++ b/src/ios/SpotifyOAuth-Bridging-Header.h
@@ -1,1 +1,1 @@
-#import <SpotifyAuthentication/SpotifyAuthentication.h>
+

--- a/src/ios/SpotifyOAuthPlugin.swift
+++ b/src/ios/SpotifyOAuthPlugin.swift
@@ -36,7 +36,7 @@ extension URL {
             queue: nil
         ) { note in
             let url = note.object as! URL
-            if(!url.absoluteString.contains("code")) { return }
+            guard url.absoluteString.contains("code") else { return }
             
             svc.presentingViewController!.dismiss(animated: true, completion: nil)
             NotificationCenter.default.removeObserver(observer!)

--- a/src/ios/SpotifyOAuthPlugin.swift
+++ b/src/ios/SpotifyOAuthPlugin.swift
@@ -14,18 +14,26 @@ extension URL {
     
     @objc(getCode:) func getCode(_ command: CDVInvokedUrlCommand) {
         let clientid = command.argument(at: 0) as! String
-        let redirectURL = URL(string: command.argument(at: 1) as! String)!
-        let tokenRefreshURL = URL(string: command.argument(at: 3) as! String)!
+        let redirectURL = command.argument(at: 1) as! String
         let requestedScopes = command.argument(at: 4) as! [String]
-        let redirectEncoded = redirectURL.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         
-        var webUrl = "https://accounts.spotify.com/authorize?client_id="+clientid+"&response_type=code&redirect_uri="
-        webUrl += redirectEncoded
-        webUrl += "&show_dialog=true&scope="
-        webUrl += scopesToString(scopes: requestedScopes)
-        webUrl += "&utm_source=spotify-sdk&utm_medium=ios-sdk&utm_campaign=ios-sdk"
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "accounts.spotify.com"
+        components.path = "/authorize"
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientid),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: redirectURL),
+            URLQueryItem(name: "show_dialog", value: "true"),
+            URLQueryItem(name: "scope", value: requestedScopes.joined(separator: " ")),
+            URLQueryItem(name: "utm_source", value: "spotify-sdk"),
+            URLQueryItem(name: "utm_medium", value: "ios-sdk"),
+            URLQueryItem(name: "utm_campaign", value: "ios-sdk")
+        ]
         
-        let svc = SFSafariViewController(url: URL(string: webUrl)!)
+        let svc = SFSafariViewController(url: components.url!)
+        
         svc.delegate = self;
         svc.modalPresentationStyle = .overFullScreen
         
@@ -56,14 +64,6 @@ extension URL {
         self.currentNsObserver = observer
         
         self.viewController.present(svc, animated: true)
-    }
-    
-    func scopesToString(scopes: [String]) -> String {
-        var result = ""
-        for scope in scopes {
-            result += scope + " "
-        }
-        return result.trimmingCharacters(in: .whitespaces).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
     }
     
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {


### PR DESCRIPTION
Plugin wasn't able to compile for iOS since the Spotify SDK it relies on isn't available anymore. The new sdk appears to have changed its API but I figured there's not need to even pull in that whole sdk dependency since we only need it for the OAuth URL.

I rewrote the code to work without this dependency, it should compile and work with iOS now.

This fixes Issue #28 