### PR TITLE
Encode encrypt refresh token in refresh http call

### DIFF
--- a/www/spotify-oauth.ts
+++ b/www/spotify-oauth.ts
@@ -165,7 +165,7 @@ function refresh(cfg: Config, data: AuthorizationData): Promise<AuthorizationDat
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded'
         },
-        body: 'refresh_token=' + data.encryptedRefreshToken
+        body: 'refresh_token=' + encodeURIComponent(data.encryptedRefreshToken)
     })
         .then(handleHttpErrors)
         .then(resp => resp.json())


### PR DESCRIPTION
Encode encrypt refresh token 

This fix is the solution to my problem sending the encrypt refresh token through http call in this plugin

- Refresh token encrypted in local storage:

U2FsdGVkX1/ReiEz6KsJg66dH5Hi+VD9eJdtHWGVzbPRPT4zy1Qobu1KTYRTchWtfljM5Vi/FZskYzOevxjucWqs0QTUfUu9tvas0ppRoJ6mSgrAM4+1Z8a47oZr2MRRlZR1JHipYLZ1HbYZ9miz2I5k2ipuQNYQuNHc0+jmrfn7AIlA3CKXuK2OqiWrvX+w8V8/iRtpM5y1GN6ICmFe5A==

- And here refresh token send in http call

refresh_token: U2FsdGVkX1/ReiEz6KsJg66dH5Hi VD9eJdtHWGVzbPRPT4zy1Qobu1KTYRTchWtfljM5Vi/FZskYzOevxjucWqs0QTUfUu9tvas0ppRoJ6mSgrAM4 1Z8a47oZr2MRRlZR1JHipYLZ1HbYZ9miz2I5k2ipuQNYQuNHc0 jmrfn7AIlA3CKXuK2OqiWrvX w8V8/iRtpM5y1GN6ICmFe5A==

It's not the same encrypted token, there are some blanks

I hope you merge this pull request to improve this plugin.

Thank you for your time.



